### PR TITLE
Fix libblobpack #2 and juci #72 issues

### DIFF
--- a/src/blob.c
+++ b/src/blob.c
@@ -16,7 +16,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <endian.h>
 #include "blob.h"
 #include "ieee754.h"
 

--- a/src/blob.h
+++ b/src/blob.h
@@ -17,6 +17,7 @@
 */
 #pragma once
 
+#include <endian.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stdint.h>


### PR DESCRIPTION
 endian.h include must be on blob.h instead of blob.c

Signed-off-by: Pau Escrich <p4u@dabax.net>